### PR TITLE
Fix: 유저정보 변경 patch에서 put으로 변경

### DIFF
--- a/src/main/java/com/udhd/apiserver/web/UserController.java
+++ b/src/main/java/com/udhd/apiserver/web/UserController.java
@@ -86,7 +86,7 @@ public class UserController {
     }
 
 
-    @PutMapping("/{userId}/nickname")
+    @PatchMapping("/{userId}/nickname")
     public UserDto setNickname(
             @PathVariable String userId,
             @RequestBody UpdateUserRequest updateUserRequest) throws DuplicateNicknameException {
@@ -108,7 +108,7 @@ public class UserController {
   }
 
 
-  @PutMapping("/{userId}/group")
+  @PatchMapping("/{userId}/group")
   public UserDto setGroup(
       @PathVariable String userId,
       @RequestBody UpdateUserRequest updateUserRequest) throws DuplicateNicknameException {


### PR DESCRIPTION
put은 전체를 갈아치운다는 개념이고 재생성으로 멱등성을 보장하므로 유저 데이터 변경에는 알맞지 않아 patch로 변경함